### PR TITLE
Use cl-lib function instead of cl.el for byte-compile warning

### DIFF
--- a/buffer-sets.el
+++ b/buffer-sets.el
@@ -138,7 +138,7 @@
 ;;;###autoload
 (defun buffer-sets-unload-last-loaded-set ()
   (interactive)
-  (let ((set (first *buffer-sets-applied*)))
+  (let ((set (cl-first *buffer-sets-applied*)))
     (buffer-sets-unload-buffer-set set)))
 
 ;;;###autoload


### PR DESCRIPTION
```
In end of data:
buffer-sets.el:313:1:Warning: the function `first' is not known to be defined.
```
